### PR TITLE
Add two additional configuration values, and their corresponding default values:

### DIFF
--- a/bitcask_test.go
+++ b/bitcask_test.go
@@ -723,6 +723,162 @@ func TestStatsError(t *testing.T) {
 	})
 }
 
+func TestDirFileModeBeforeUmask(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("Setup", func(t *testing.T) {
+		t.Run("Default DirFileModeBeforeUmask is 0700", func(t *testing.T) {
+			testdir, err := ioutil.TempDir("", "bitcask")
+			embeddedDir := filepath.Join(testdir, "cache")
+			assert.NoError(err)
+			defer os.RemoveAll(testdir)
+
+			defaultTestMode := os.FileMode(0700)
+
+			db, err := Open(embeddedDir)
+			defer db.Close()
+			assert.NoError(err)
+			err = filepath.Walk(testdir, func(path string, info os.FileInfo, err error) error {
+				// skip the root directory
+				if path == testdir {
+					return nil
+				}
+				if info.IsDir() {
+					// perms for directory on disk are filtered through defaultTestMode, AND umask of user running test.
+					// this means the mkdir calls can only FURTHER restrict permissions, not grant more (preventing escalatation).
+					// to make this test OS agnostic, we'll skip using golang.org/x/sys/unix, inferring umask via XOR and AND NOT.
+
+					// create anotherDir with allPerms - to infer umask
+					anotherDir := filepath.Join(testdir, "temp")
+					allPerms := os.FileMode(0777)
+					err := os.Mkdir(anotherDir, allPerms)
+					assert.NoError(err)
+					defer os.RemoveAll(anotherDir)
+
+					anotherStat, err := os.Stat(anotherDir)
+					assert.NoError(err)
+
+					// infer umask from anotherDir
+					umask := allPerms ^ (anotherStat.Mode() & os.ModePerm)
+
+					assert.Equal(info.Mode()&os.ModePerm, defaultTestMode&^umask)
+				}
+				return nil
+			})
+			assert.NoError(err)
+		})
+
+		t.Run("Dir FileModeBeforeUmask is set via options for all subdirectories", func(t *testing.T) {
+			testdir, err := ioutil.TempDir("", "bitcask")
+			embeddedDir := filepath.Join(testdir, "cache")
+			assert.NoError(err)
+			defer os.RemoveAll(testdir)
+
+			testMode := os.FileMode(0713)
+
+			db, err := Open(embeddedDir, WithDirFileModeBeforeUmask(testMode))
+			defer db.Close()
+			assert.NoError(err)
+			err = filepath.Walk(testdir, func(path string, info os.FileInfo, err error) error {
+				// skip the root directory
+				if path == testdir {
+					return nil
+				}
+				if info.IsDir() {
+					// create anotherDir with allPerms - to infer umask
+					anotherDir := filepath.Join(testdir, "temp")
+					allPerms := os.FileMode(0777)
+					err := os.Mkdir(anotherDir, allPerms)
+					assert.NoError(err)
+					defer os.RemoveAll(anotherDir)
+
+					anotherStat, _ := os.Stat(anotherDir)
+
+					// infer umask from anotherDir
+					umask := allPerms ^ (anotherStat.Mode() & os.ModePerm)
+
+					assert.Equal(info.Mode()&os.ModePerm, testMode&^umask)
+				}
+				return nil
+			})
+			assert.NoError(err)
+		})
+
+	})
+}
+
+func TestFileFileModeBeforeUmask(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("Setup", func(t *testing.T) {
+		t.Run("Default File FileModeBeforeUmask is 0600", func(t *testing.T) {
+			testdir, err := ioutil.TempDir("", "bitcask")
+			assert.NoError(err)
+			defer os.RemoveAll(testdir)
+
+			defaultTestMode := os.FileMode(0600)
+
+			db, err := Open(testdir)
+			defer db.Close()
+			assert.NoError(err)
+			err = filepath.Walk(testdir, func(path string, info os.FileInfo, err error) error {
+				if !info.IsDir() {
+					// create aFile with allPerms - to infer umask
+					aFilePath := filepath.Join(testdir, "temp")
+					allPerms := os.FileMode(0777)
+					_, err := os.OpenFile(aFilePath, os.O_CREATE, allPerms)
+					assert.NoError(err)
+					defer os.RemoveAll(aFilePath)
+
+					fileStat, _ := os.Stat(aFilePath)
+
+					// infer umask from anotherDir
+					umask := allPerms ^ (fileStat.Mode() & os.ModePerm)
+
+					assert.Equal(info.Mode()&os.ModePerm, defaultTestMode&^umask)
+				}
+				return nil
+			})
+			assert.NoError(err)
+		})
+
+		t.Run("File FileModeBeforeUmask is set via options for all files", func(t *testing.T) {
+			testdir, err := ioutil.TempDir("", "bitcask")
+			assert.NoError(err)
+			defer os.RemoveAll(testdir)
+
+			testMode := os.FileMode(0673)
+
+			db, err := Open(testdir, WithFileFileModeBeforeUmask(testMode))
+			defer db.Close()
+			assert.NoError(err)
+			err = filepath.Walk(testdir, func(path string, info os.FileInfo, err error) error {
+				if !info.IsDir() {
+					// the lock file is set within Flock, so ignore it
+					if filepath.Base(path) == "lock" {
+						return nil
+					}
+					// create aFile with allPerms - to infer umask
+					aFilePath := filepath.Join(testdir, "temp")
+					allPerms := os.FileMode(0777)
+					_, err := os.OpenFile(aFilePath, os.O_CREATE, allPerms)
+					assert.NoError(err)
+					defer os.RemoveAll(aFilePath)
+
+					fileStat, _ := os.Stat(aFilePath)
+
+					// infer umask from anotherDir
+					umask := allPerms ^ (fileStat.Mode() & os.ModePerm)
+
+					assert.Equal(info.Mode()&os.ModePerm, testMode&^umask)
+				}
+				return nil
+			})
+			assert.NoError(err)
+		})
+	})
+}
+
 func TestMaxDatafileSize(t *testing.T) {
 	var (
 		db  *Bitcask

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,7 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/redcon v1.3.2 h1:8INx/Nm3VSUbDUT16TH1rMgYQsbXNqy9xcX70edHXbo=
 github.com/tidwall/redcon v1.3.2/go.mod h1:bdYBm4rlcWpst2XMwKVzWDF9CoUxEbUmM7CQrKeOZas=
+github.com/tidwall/redcon v1.3.3 h1:BkvIOVPSMw7JnPlyjaSCckgEhvXCy3U5GgKkssveax4=
 github.com/tidwall/redcon v1.3.3/go.mod h1:bdYBm4rlcWpst2XMwKVzWDF9CoUxEbUmM7CQrKeOZas=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,15 +3,18 @@ package config
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 )
 
 // Config contains the bitcask configuration parameters
 type Config struct {
-	MaxDatafileSize int    `json:"max_datafile_size"`
-	MaxKeySize      uint32 `json:"max_key_size"`
-	MaxValueSize    uint64 `json:"max_value_size"`
-	Sync            bool   `json:"sync"`
-	AutoRecovery    bool   `json:"autorecovery"`
+	MaxDatafileSize         int    `json:"max_datafile_size"`
+	MaxKeySize              uint32 `json:"max_key_size"`
+	MaxValueSize            uint64 `json:"max_value_size"`
+	Sync                    bool   `json:"sync"`
+	AutoRecovery            bool   `json:"autorecovery"`
+	DirFileModeBeforeUmask  os.FileMode
+	FileFileModeBeforeUmask os.FileMode
 }
 
 // Load loads a configuration from the given path
@@ -38,10 +41,10 @@ func (c *Config) Save(path string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(path, data, 0600)
+	err = ioutil.WriteFile(path, data, c.FileFileModeBeforeUmask)
 	if err != nil {
 		return err
 	}
-	
+
 	return nil
 }

--- a/internal/data/datafile.go
+++ b/internal/data/datafile.go
@@ -48,7 +48,7 @@ type datafile struct {
 }
 
 // NewDatafile opens an existing datafile
-func NewDatafile(path string, id int, readonly bool, maxKeySize uint32, maxValueSize uint64) (Datafile, error) {
+func NewDatafile(path string, id int, readonly bool, maxKeySize uint32, maxValueSize uint64, fileMode os.FileMode) (Datafile, error) {
 	var (
 		r   *os.File
 		ra  *mmap.ReaderAt
@@ -59,7 +59,7 @@ func NewDatafile(path string, id int, readonly bool, maxKeySize uint32, maxValue
 	fn := filepath.Join(path, fmt.Sprintf(defaultDatafileFilename, id))
 
 	if !readonly {
-		w, err = os.OpenFile(fn, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0640)
+		w, err = os.OpenFile(fn, os.O_WRONLY|os.O_APPEND|os.O_CREATE, fileMode)
 		if err != nil {
 			return nil, err
 		}

--- a/options.go
+++ b/options.go
@@ -1,8 +1,18 @@
 package bitcask
 
-import "github.com/prologic/bitcask/internal/config"
+import (
+	"os"
+
+	"github.com/prologic/bitcask/internal/config"
+)
 
 const (
+	// DefaultDirFileModeBeforeUmask is the default os.FileMode used when creating directories
+	DefaultDirFileModeBeforeUmask = os.FileMode(0700)
+
+	// DefaultFileFileModeBeforeUmask is the default os.FileMode used when creating files
+	DefaultFileFileModeBeforeUmask = os.FileMode(0600)
+
 	// DefaultMaxDatafileSize is the default maximum datafile size in bytes
 	DefaultMaxDatafileSize = 1 << 20 // 1MB
 
@@ -27,6 +37,22 @@ type Option func(*config.Config) error
 func WithAutoRecovery(enabled bool) Option {
 	return func(cfg *config.Config) error {
 		cfg.AutoRecovery = enabled
+		return nil
+	}
+}
+
+// WithDirFileModeBeforeUmask sets the FileMode used for each new file created.
+func WithDirFileModeBeforeUmask(mode os.FileMode) Option {
+	return func(cfg *config.Config) error {
+		cfg.DirFileModeBeforeUmask = mode
+		return nil
+	}
+}
+
+// WithFileFileModeBeforeUmask sets the FileMode used for each new file created.
+func WithFileFileModeBeforeUmask(mode os.FileMode) Option {
+	return func(cfg *config.Config) error {
+		cfg.FileFileModeBeforeUmask = mode
 		return nil
 	}
 }
@@ -66,9 +92,11 @@ func WithSync(sync bool) Option {
 
 func newDefaultConfig() *config.Config {
 	return &config.Config{
-		MaxDatafileSize: DefaultMaxDatafileSize,
-		MaxKeySize:      DefaultMaxKeySize,
-		MaxValueSize:    DefaultMaxValueSize,
-		Sync:            DefaultSync,
+		MaxDatafileSize:         DefaultMaxDatafileSize,
+		MaxKeySize:              DefaultMaxKeySize,
+		MaxValueSize:            DefaultMaxValueSize,
+		Sync:                    DefaultSync,
+		DirFileModeBeforeUmask:  DefaultDirFileModeBeforeUmask,
+		FileFileModeBeforeUmask: DefaultFileFileModeBeforeUmask,
 	}
 }


### PR DESCRIPTION
* DirFileModeBeforeUmask - Dir FileMode is used on all directories created.  DefaultDirFileModeBeforeUmask is 0700.
* FileFileModeBeforeUmask - File FileMode is used on all files created, except for the "lock" file (managed by the Flock library).  DefaultFileFileModeBeforeUmask is 0600.

When using these bits of configuration, keep in mind these FileMode values are set BEFORE any umask rules are applied.  For example, if the user's umask is 022, setting DirFileFileModeBeforeUmask to 777 will result in directories with FileMode set to 755 (this umask prevents the write bit from being applied to group and world permissions).